### PR TITLE
Rename from timestamp to epoch secs

### DIFF
--- a/SQLITE.md
+++ b/SQLITE.md
@@ -7,7 +7,7 @@ The table structure is as follows:
 
 ```
 CREATE TABLE IF NOT EXISTS entries (
-  timestamp LONG, // number of seconds since epoch
+  epoch_secs LONG, // number of seconds since epoch
   nanos INTEGER,  // nanoseconds in the second
   level INTEGER,  // numeric level of logging
   content BLOB    // raw bytes from logging framework encoder / layout
@@ -18,9 +18,9 @@ There are no indices on any columns, for speed of inserts.  You are free to add 
 expect to be querying on a regular basis:
 
 ```
-CREATE INDEX IF NOT EXISTS timestamp_idx ON entries (timestamp);
+CREATE INDEX IF NOT EXISTS epoch_secs_idx ON entries (epoch_secs);
 CREATE INDEX IF NOT EXISTS level_idx ON entries (level);
-``` 
+```
 
 Also note that if you are using structured logging, you can [index using expressions](https://www.sqlite.org/expridx.html), including over JSON:
 
@@ -32,9 +32,9 @@ Because the database shows the timestamp as seconds since epoch, a view is added
  the timestamp in both UTC and local time.
 
 ```
-CREATE VIEW IF NOT EXISTS entries_view AS 
-  SELECT datetime(timestamp, 'unixepoch', 'utc') as timestamp_utc,
-  datetime(timestamp, 'unixepoch', 'localtime') as timestamp_local,
+CREATE VIEW IF NOT EXISTS entries_view AS
+  SELECT datetime(epoch_secs, 'unixepoch', 'utc') as timestamp_utc,
+  datetime(epoch_secs, 'unixepoch', 'localtime') as timestamp_local,
   nanos, level, content
   FROM entries
 ```
@@ -53,8 +53,8 @@ And from there you can do individual queries (the `identity` codec is used here 
  encoding):
 
 ```sqlite-psql
-SELECT _rowid_, datetime(timestamp, 'unixepoch', 'localtime'), nanos, content FROM entries 
-WHERE content IS NOT NULL ORDER BY timestamp ASC LIMIT 0, 100;
+SELECT _rowid_, datetime(epoch_secs, 'unixepoch', 'localtime'), nanos, content FROM entries
+WHERE content IS NOT NULL ORDER BY epoch_secs ASC LIMIT 0, 100;
 ```
 
 ```
@@ -75,11 +75,11 @@ and get back:
 ```
 
 If you are using structured logging, you can query the content directly using the [JSON
- extensions](https://www.sqlite.org/json1.html): 
+ extensions](https://www.sqlite.org/json1.html):
 
 ```
 sqlite3 live.db "SELECT * FROM entries_view WHERE json_extract(content, '$.message') LIKE
- 'warning%' LIMIT 1" 
+ 'warning%' LIMIT 1"
 ```
 
 You can also select an individual row using the rowid, an implicit autoincrementing primary key
@@ -100,8 +100,8 @@ XXX I don't have epoch nanoseconds working here :-/
 
 ### JSON Support
 
-https://www.sqlite.org/json1.html 
- 
+https://www.sqlite.org/json1.html
+
 The CLI also lets you do `json_extract` on various logs:
 
 ```
@@ -117,25 +117,25 @@ sqlite> SELECT _rowid_,* FROM entries WHERE json_extract(content,'$.message') LI
 |
 6940073|1602382138|679000000|30000|{"@timestamp":"2020-10-10T19:08:58.679-07:00","@version":"1","message":"debugging is fun!!! 2020-10-11T02:08:58.679486Z","logger_name":"com.tersesystems.rifter.logback.Main","thread_name":"main","level":"WARN","level_value":30000}
 |
-sqlite> 
+sqlite>
 ```
 
 Note we get back two rows here.  This is because the nanotime resolution is not absolute, and so
  it's possible for two different statements to show up in the same nanosecond.  If you're
   spitting out logs, you may want to include a unique flake id or counter so that you can
    distinguish them.
-   
+
 You can also query from the command line:
 
 ```
-sqlite3 ./rifter.db "SELECT json_extract(content,'$.message') FROM entries WHERE _rowid_ = 6940072" 
+sqlite3 ./rifter.db "SELECT json_extract(content,'$.message') FROM entries WHERE _rowid_ = 6940072"
 debugging is fun!!! 2020-10-11T02:08:58.679486Z
 ```
 
 or you can extract the JSON directly to stdout and pass it through `jq`:
 
 ```
-❱ sqlite3 ./rifter.db  "SELECT content FROM entries WHERE content IS NOT NULL LIMIT 1" | jq 
+❱ sqlite3 ./rifter.db  "SELECT content FROM entries WHERE content IS NOT NULL LIMIT 1" | jq
 {
   "@timestamp": "2020-10-10T19:08:58.679-07:00",
   "@version": "1",
@@ -159,7 +159,7 @@ If you look at the file with `vi`, you'll see plain text.  This is because vi is
  autodecode for you. Don't be deceived, it's actually still zstandard:
 
 ```
-❱ hexdump 1.zst 
+❱ hexdump 1.zst
 0000000 b528 fd2f e720 059d 7200 268b 3022 568b
 0000010 0301 966d 5525 8f8e 1a94 5e28 0523 e1fc
 0000020 b8a4 4e43 b0ee cb33 f054 30fc 4080 889d
@@ -171,15 +171,15 @@ If you look at the file with `vi`, you'll see plain text.  This is because vi is
 0000080 4786 df57 c6c7 e4b5 7167 d574 ba5d 1428
 0000090 0d2b aee8 1580 0c50 28b5 cca3 0cf7 cd90
 00000a0 e866 e2e6 010e 0008 0132 1c38 e712 c5b8
-00000b0 c54a 8210 9285 1403 34ea 7770          
+00000b0 c54a 8210 9285 1403 34ea 7770
 00000bc
 ```
 
 And you can decrypt it as follows:
 
 ```
-❱ zstd -d 1.zst 
-1.zst               : 231 bytes 
+❱ zstd -d 1.zst
+1.zst               : 231 bytes
 ```
 
 ## Python support with sqlite-utils
@@ -188,7 +188,7 @@ Extracting content is simple and easy using [sqlite-utils](https://sqlite-utils.
 /stable/):
 
 ```bash
-sudo apt install python3-pip  
+sudo apt install python3-pip
 sudo pip3 install sqlite-utils
 sudo pip3 install zstandard
 ```
@@ -211,18 +211,18 @@ dict_row = db.execute("select dict_bytes from zstd_dicts LIMIT 1").fetchone()
 dict = zstd.ZstdCompressionDict(dict_row[0])
 dctx = zstd.ZstdDecompressor(dict_data = dict)
 
-for row in db["entries"].rows_where("timestamp < ? limit 1", [epoch_time]):
-    timestamp = row['timestamp']
+for row in db["entries"].rows_where("epoch_secs < ? limit 1", [epoch_time]):
+    epoch_secs = row['epoch_secs']
     level = row['level']
     content = json.loads(dctx.decompress(row['content']))
-    print("timestamp = ", timestamp, "level = ", level, "message = ", content['message'])
+    print("epoch_secs = ", epoch_secs, "level = ", level, "message = ", content['message'])
 ```
 
 This produces:
 
 ```
 ❱ ./reader.py
-timestamp =  1603055625 level =  10000 message =  debugging is fun!!! 2020-10-18T21:13:45.317090Z
+epoch_secs =  1603055625 level =  10000 message =  debugging is fun!!! 2020-10-18T21:13:45.317090Z
 ```
 
 You can also use SQL custom functions, which allows you to use SQLite's JSON functions natively:
@@ -247,7 +247,7 @@ dctx = zstd.ZstdDecompressor(dict_data = dict)
 def decode(s):
     return dctx.decompress(s)
 
-sql = """select 
+sql = """select
 timestamp_utc,
 json_extract(decode(content),'$.message') as message,
 decode(content) as decoded

--- a/blacklite-core/src/main/resources/com/tersesystems/blacklite/resources.properties
+++ b/blacklite-core/src/main/resources/com/tersesystems/blacklite/resources.properties
@@ -1,15 +1,16 @@
-entries.create.statement=CREATE TABLE IF NOT EXISTS entries (timestamp LONG,\
+entries.create.statement=CREATE TABLE IF NOT EXISTS entries (\
+  epoch_secs LONG,\
   nanos INTEGER,\
   level INTEGER,\
   content BLOB)
 
 entries_view.create.statement=CREATE VIEW IF NOT EXISTS entries_view AS \
-  SELECT datetime(timestamp, 'unixepoch', 'utc') as timestamp_utc,  \
-  datetime(timestamp, 'unixepoch', 'localtime') as timestamp_local, \
+  SELECT datetime(epoch_secs, 'unixepoch', 'utc') as timestamp_utc,  \
+  datetime(epoch_secs, 'unixepoch', 'localtime') as timestamp_local, \
   nanos, level, content \
   FROM entries
 
-entries.insert.statement=INSERT INTO entries(timestamp, nanos, level, content) values(?, ?, ?, ?)
+entries.insert.statement=INSERT INTO entries(epoch_secs, nanos, level, content) values(?, ?, ?, ?)
 
 # https://stackoverflow.com/a/34018187/5266
 entries.numrows.statement=select MaxRowId - MinRowId + 1 from (select max(_rowid_) as MaxRowId from entries) JOIN (select min(_rowid_) as MinRowId from entries)
@@ -24,8 +25,8 @@ entries.deletelessthan.statement=DELETE FROM entries WHERE entries._rowid_ <= ?
 
 entries.oldest.statement=SELECT _rowid_,* FROM entries WHERE _rowid_ <= ? ORDER BY _rowid_ LIMIT ?
 
-entries.archive.statement=INSERT INTO archive.entries(timestamp, nanos, level, content) \
-  SELECT timestamp, nanos, level, encode(content) FROM entries \
+entries.archive.statement=INSERT INTO archive.entries(epoch_secs, nanos, level, content) \
+  SELECT epoch_secs, nanos, level, encode(content) FROM entries \
   WHERE entries._rowid_ <= ?
 
 entries.attach.statement=ATTACH '%s' AS archive

--- a/blacklite-reader/src/main/java/com/tersesystems/blacklite/reader/QueryBuilder.java
+++ b/blacklite-reader/src/main/java/com/tersesystems/blacklite/reader/QueryBuilder.java
@@ -80,14 +80,14 @@ class QueryBuilder {
     }
 
     if (before != null) {
-      sb.append(" timestamp < ? ");
+      sb.append("epoch_secs < ? ");
       if (boundParams > 1) {
         sb.append(" AND ");
       }
     }
 
     if (after != null) {
-      sb.append(" timestamp > ? ");
+      sb.append("epoch_secs > ? ");
       if (whereString != null && !whereString.isEmpty()) {
         sb.append(" AND ");
       }

--- a/blacklite-reader/src/test/java/com/tersesystems/blacklite/reader/BlackliteReaderTest.java
+++ b/blacklite-reader/src/test/java/com/tersesystems/blacklite/reader/BlackliteReaderTest.java
@@ -118,7 +118,7 @@ public class BlackliteReaderTest {
     final String sql = actual.createSQL();
     assertThat(sql)
         .isEqualTo(
-            "SELECT content FROM entries WHERE  timestamp < ?  AND  timestamp > ?  AND level > 9000");
+            "SELECT content FROM entries WHERE epoch_secs < ?  AND epoch_secs > ?  AND level > 9000");
   }
 
   @Test
@@ -131,7 +131,7 @@ public class BlackliteReaderTest {
     final String sql = actual.createSQL();
     assertThat(sql)
         .isEqualTo(
-            "SELECT COUNT(*) FROM entries WHERE  timestamp < ?  AND  timestamp > ?  AND level > 9000");
+            "SELECT COUNT(*) FROM entries WHERE epoch_secs < ?  AND epoch_secs > ?  AND level > 9000");
   }
 
   static class TestBlackliteReader extends BlackliteReader {


### PR DESCRIPTION
Rename`timestamp` to `epoch_sec` because timestamp is a keyword and it confuses IDEs