### PR TITLE
Upgrade to log4j2 2.17.2

### DIFF
--- a/blacklite-log4j2/blacklite-log4j2.gradle
+++ b/blacklite-log4j2/blacklite-log4j2.gradle
@@ -6,5 +6,5 @@ dependencies {
     api project(':blacklite-core')
 
     // https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core
-    api group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.13.3'
+    api group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.2'
 }


### PR DESCRIPTION
Should make this a `provided` dependency as well, but `2.17.2` is a good start.